### PR TITLE
Replaced stale react-native-voice with react-native-community/voice

### DIFF
--- a/components/Chat.tsx
+++ b/components/Chat.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useEffect, memo} from 'react';
 import {GiftedChat, IMessage} from 'react-native-gifted-chat';
 // @ts-ignore
-import Voice from 'react-native-voice';
+import Voice from '@react-native-community/voice';
 import {View} from 'react-native';
 
 import {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-native-dialogflow": "^3.2.2",
     "react-native-gifted-chat": "^0.13.0",
     "react-native-tts": "^3.1.1",
-    "react-native-voice": "^0.3.0",
+    "@react-native-community/voice": "^1.1.30",
     "uuid": "^3.4.0"
   },
   "repository": {


### PR DESCRIPTION
Hi, I tried using the package (Great package by the way)... but ran into various issues because  react-native-voice (a peer dependency) was not being supported anymore... It has since been moved to @zaporozhetsAnton react-native-community/voice.. 
I fixed this in the package.json and the Chat.Tsx files and that fixed the issue.
